### PR TITLE
Separate download subsystem into completely different worker

### DIFF
--- a/bqueryd/__init__.py
+++ b/bqueryd/__init__.py
@@ -13,7 +13,7 @@ if not os.path.exists(INCOMING):
     os.makedirs(INCOMING)
 
 REDIS_SET_KEY = 'bqueryd_controllers'
-REDIS_DOWNLOAD_FILES_KEY = 'bqueryd_downloads'
+REDIS_TICKET_KEY_PREFIX = 'bqueryd_download_ticket_'
 # TODO dynamic nature of DQEng failing now due to out-of-memory errors. hard-code this and revisit soon to make it more dynamic again
 NODES = ['dqe11', 'dqe12', 'dqe13', 'dqe14', 'dqe15']
 

--- a/bqueryd/__init__.py
+++ b/bqueryd/__init__.py
@@ -19,5 +19,5 @@ NODES = ['dqe11', 'dqe12', 'dqe13', 'dqe14', 'dqe15']
 
 from rpc import RPC, RPCError
 from controller import ControllerNode
-from worker import WorkerNode
+from worker import WorkerNode, DownloaderNode
 

--- a/bqueryd/controller.py
+++ b/bqueryd/controller.py
@@ -263,6 +263,7 @@ class ControllerNode(object):
     def handle_in(self):
         self.msg_count_in += 1
         data = self.socket.recv_multipart()
+        binary, sender = None, None # initialise outside for edge cases
         if len(data) == 3:
             if data[1] == '': # This is a RPC call from a zmq.REQ socket
                 sender, _blank, msg_buf = data
@@ -271,7 +272,6 @@ class ControllerNode(object):
             sender, msg_buf, binary = data
         elif len(data) == 2:  # This is an internode call from another zmq.ROUTER, a Controller or Worker
             sender, msg_buf = data
-            binary = None
         msg = msg_factory(msg_buf)
         if binary:
             msg['data'] = binary
@@ -427,15 +427,8 @@ class ControllerNode(object):
         # Turn filenames into s3 URLs
         filenames = ['s3://%s/%s' % (bucket, filename) for filename in filenames]
 
-        # Check each filename for a ticket and see if is currently being downloaded...
-        download_tickets = self.redis_server.hgetall(bqueryd.REDIS_DOWNLOAD_FILES_KEY)
-        filenames = [x for x in filenames if x not in download_tickets]
-        if not filenames:
-            return "All files are currently being downloaded"
-
         ticket = binascii.hexlify(os.urandom(8))  # track all downloads using a ticket
         for filename in filenames:
-            self.redis_server.hset(bqueryd.REDIS_DOWNLOAD_FILES_KEY, filename, ticket)
 
             # get all node names from others + self
             # TODO if the download happens to start when you are disconnected from others this is an issue...
@@ -446,7 +439,7 @@ class ControllerNode(object):
                 # A progress slot contains a timestamp_filesize
                 progress_slot = '%s_%s' % (0, -1)  # start the progress with a timestamp of loooon ago
                 node_filename_slot = '%s_%s' % (node, filename)
-                self.redis_server.hset('ticket_' + ticket, node_filename_slot, progress_slot)
+                self.redis_server.hset(bqueryd.REDIS_TICKET_KEY_PREFIX + ticket, node_filename_slot, progress_slot)
 
         if wait:
             msg.add_as_binary('result', ticket)
@@ -539,7 +532,7 @@ class ControllerNode(object):
                 self.remove_worker(worker_id)
 
     def go(self):
-        self.logger.info('Starting #####################################')
+        self.logger.info('[#############################>. Starting .<#############################]')
 
         while self.is_running:
             try:

--- a/bqueryd/messages.py
+++ b/bqueryd/messages.py
@@ -13,6 +13,7 @@ def msg_factory(msg):
     msg_mapping = {'calc': CalcMessage, 'rpc': RPCMessage, 'error': ErrorMessage,
                    'worker_register': WorkerRegisterMessage,
                    'busy': BusyMessage, 'done': DoneMessage,
+                   'ticketdone': TicketDoneMessage,
                    'stop': StopMessage, None: Message}
     msg_class = msg_mapping.get(msg.get('msg_type'))
     return msg_class(msg)
@@ -93,3 +94,7 @@ class DoneMessage(Message):
 
 class StopMessage(Message):
     msg_type = 'stop'
+
+
+class TicketDoneMessage(Message):
+    msg_type = 'ticketdone'

--- a/bqueryd/node.py
+++ b/bqueryd/node.py
@@ -20,6 +20,8 @@ if __name__ == '__main__':
         bqueryd.ControllerNode(redis_url=redis_url, loglevel=loglevel).go()
     elif 'worker' in sys.argv:
         bqueryd.WorkerNode(redis_url=redis_url, loglevel=loglevel).go()
+    elif 'downloader' in sys.argv:
+        bqueryd.DownloaderNode(redis_url=redis_url, loglevel=loglevel).go()
     else:
         if len(sys.argv) > 1 and sys.argv[1].startswith('tcp:'):
             rpc = bqueryd.RPC(address=sys.argv[1], redis_url=redis_url, loglevel=loglevel)

--- a/bqueryd/worker.py
+++ b/bqueryd/worker.py
@@ -19,6 +19,7 @@ import zipfile
 from ssl import SSLError
 import shutil
 import errno
+import signal
 from bqueryd.messages import msg_factory, WorkerRegisterMessage, ErrorMessage, BusyMessage, StopMessage, \
     DoneMessage, TicketDoneMessage
 from bqueryd.tool import rm_file_or_dir
@@ -56,6 +57,13 @@ class WorkerBase(object):
         self.logger = bqueryd.logger.getChild('worker ' + self.worker_id)
         self.logger.setLevel(loglevel)
         self.msg_count = 0
+        signal.signal(signal.SIGTERM, self.term_signal())
+
+    def term_signal(self):
+        def _signal_handler(signum, frame):
+            self.logger.info("Received TERM signal, stopping.")
+            self.running = False
+        return _signal_handler
 
     def send(self, addr, msg):
         try:

--- a/misc/supervisor.conf
+++ b/misc/supervisor.conf
@@ -1,0 +1,39 @@
+; Supervisor configuration for bqueryd controllers and workers
+
+[program:bqueryd_controller]
+command=/srv/python/venv/bin/python /srv/src/bqueryd/bqueryd/node.py controller
+directory=/srv/tmp/
+user=ubuntu
+numprocs=1
+stdout_logfile=/var/log/supervisor/bqueryd_controller.log
+stderr_logfile=/var/log/supervisor/bqueryd_controller.log
+autostart=true
+autorestart=true
+startretries=10
+startsecs=10
+
+[program:bqueryd_worker]
+command=/srv/python/venv/bin/python /srv/src/bqueryd/bqueryd/node.py worker
+directory=/srv/tmp/
+user=ubuntu
+process_name=%(program_name)s_%(process_num)02d
+numprocs=10
+numprocs_start=1
+stdout_logfile=/var/log/supervisor/bqueryd_worker_%(process_num)02d.log
+stderr_logfile=/var/log/supervisor/bqueryd_worker_%(process_num)02d.log
+autostart=true
+autorestart=true
+startretries=10
+startsecs=10
+
+[program:bqueryd_downloader]
+command=/srv/python/venv/bin/python /srv/src/bqueryd/bqueryd/node.py downloader
+directory=/srv/tmp/
+user=ubuntu
+numprocs=1
+stdout_logfile=/var/log/supervisor/bqueryd_downloader.log
+stderr_logfile=/var/log/supervisor/bqueryd_downloader.log
+autostart=true
+autorestart=true
+startretries=10
+startsecs=10


### PR DESCRIPTION
There has been some hard to identify issues with the downloads not being reliable.
Suspicision is that it is due to race conditions with multiple workers doing downloads at the same time.
This branch separates the download worker into  a different type.
The worker class now also has a base class that can be used in future to make other specialised workers, while still integrating in the base message passing infrastructure for being started/stopped etc.