### PR TITLE
Use /srv/tmp instead of /tmp

### DIFF
--- a/misc/supervisor.conf
+++ b/misc/supervisor.conf
@@ -11,6 +11,7 @@ autostart=true
 autorestart=true
 startretries=10
 startsecs=10
+environment=TMP="/srv/tmp",TEMP="/srv/tmp",TMPFILE="/srv/tmp"
 
 [program:bqueryd_worker]
 command=/srv/python/venv/bin/python /srv/src/bqueryd/bqueryd/node.py worker
@@ -25,6 +26,7 @@ autostart=true
 autorestart=true
 startretries=10
 startsecs=10
+environment=TMP="/srv/tmp",TEMP="/srv/tmp",TMPFILE="/srv/tmp"
 
 [program:bqueryd_downloader]
 command=/srv/python/venv/bin/python /srv/src/bqueryd/bqueryd/node.py downloader
@@ -37,3 +39,4 @@ autostart=true
 autorestart=true
 startretries=10
 startsecs=10
+environment=TMP="/srv/tmp",TEMP="/srv/tmp",TMPFILE="/srv/tmp"


### PR DESCRIPTION
Hi @eposthumus! This should solve the problem of using /tmp dir instead of /srv/tmp/.

BTW i've also configured TEMP, TMP & TMPDIR variables in both /etc/environment and sudoers Default 