### PR TITLE
Revert "Do not print Resource unavailable to stdout (print to logger instead)"

### DIFF
--- a/bqueryd/rpc.py
+++ b/bqueryd/rpc.py
@@ -46,8 +46,8 @@ class RPC(object):
                 reply = msg_factory(tmp_sock.recv_json())
                 self.address = c
                 break
-            except Exception as e:
-                self.logger.debug(str(e))
+            except:
+                traceback.print_exc()
                 continue
         if reply:
             # Now set the timeout to the actual requested


### PR DESCRIPTION
Reverts visualfabriq/bqueryd#16

I really disagree with ignoring errors by "closing your eyes", if anything it should maybe do both. in general, the unavailability of a controller should be noted