### PR TITLE
Additional logging levels

### DIFF
--- a/bqueryd/node.py
+++ b/bqueryd/node.py
@@ -11,10 +11,14 @@ redis_url = config.get('redis_url', 'redis://127.0.0.1:6379/0')
 
 
 def main():
-    if '-v' in sys.argv:
+    if '-vvv' in sys.argv:
         loglevel = logging.DEBUG
-    else:
+    elif '-vv' in sys.argv:
         loglevel = logging.INFO
+    elif '-v' in sys.argv:
+        loglevel = logging.WARNING
+    else:
+        loglevel = logging.ERROR
 
     data_dir = bqueryd.DEFAULT_DATA_DIR
     for arg in sys.argv:


### PR DESCRIPTION
Allow additional verbose parameters: 

'-vvv' for DEBUG logging level
'-vv' for INFO logging level
'-v' for WARNING logging level

Default logging level is ERROR.

NB. Once merged we need to upload a new version to pypi + set up the new version on requirements.txt